### PR TITLE
2 - Fix line and column error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # NEXT-VERSION
-
+- [Bugfix #2](https://github.com/MalteJanz/ludtwig-parser/issues/2):
+  Line and column numbers for the human-readable errors should now be correct regardless of the line ending.
+  They now also work correctly with utf-8 files.
 
 # v0.3.0
 - Mostly fixed a performance regression:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use nom::error::{ContextError, ErrorKind};
 use nom::lib::std::fmt::Formatter;
 use std::borrow::Cow;
+use std::cmp::min;
 use std::error::Error;
 use std::fmt::Display;
 
@@ -175,54 +176,158 @@ impl SubsliceOffset for str {
 
 /// Given the raw input and a slice of the input.
 /// Outputs the line and column number of the slice inside the input and
-/// the whole last line which contains the slice.
-///
-/// # Warning
-/// This function will most likely not work correctly with UTF8 strings because it iterates over bytes.
-fn get_line_and_column_of_subslice<'a>(input: &'a str, slice: &'a str) -> (usize, usize, &'a str) {
+/// the whole last line which contains the slice beginning.
+/// The last line does not contain any '\t' bytes and contains four ' ' spaces instead
+/// (because columns are counted like this).
+fn get_line_and_column_of_subslice<'a>(
+    input: &'a str,
+    slice: &'a str,
+) -> (usize, usize, Cow<'a, str>) {
     let offset = input.subslice_offset(slice).unwrap();
-    let mut last_line_start = 0;
-    let mut last_line_end = 1;
-    let mut found = false;
-    let mut lines = 0;
-    let mut byte_number = 0;
-    let mut last_byte = None;
 
-    for (i, byte) in input.bytes().enumerate() {
-        byte_number = i;
-        if byte == b'\r' || byte == b'\n' {
-            last_line_end = i + 1;
-
-            if let Some(l_byte) = last_byte {
-                if l_byte != b'\r' || l_byte != b'\n' {
-                    lines += 1;
-                }
-            }
-
-            if found {
-                break;
-            }
-
-            last_line_start = last_line_end;
+    // count the lines and columns up to the slice position (offset)
+    let mut line_start_offset: usize = 0;
+    let mut line: usize = 1;
+    let mut column: usize = 0;
+    let mut tab_in_line_found: bool = false;
+    for (i, char) in input[..min(input.len(), offset + 1)].char_indices() {
+        if char == '\n' {
+            line += 1;
+            line_start_offset = i + char.len_utf8();
+            column = 0;
+            tab_in_line_found = false;
+            continue;
         }
 
-        if i == offset {
-            found = true;
+        if char == '\r' {
+            // don't count this special byte as a column
+            continue;
         }
 
-        last_byte = Some(byte);
+        if char == '\t' {
+            // count a tab as 4 columns
+            column += 4;
+            tab_in_line_found = true;
+        } else {
+            column += 1;
+        }
     }
 
-    // if the for loop did not found a newline in the last parsed line the end and start will be the same.
-    if last_line_start == last_line_end {
-        last_line_end = byte_number + 1;
-        lines += 1;
-    } else {
-        last_line_end -= 1;
+    if input.len() == offset {
+        // the offset is outside the input string (so to points to basically to the next character behind the input string).
+        // in this case the column should also point to that position.
+        column += 1;
     }
 
-    let last_line = &input[last_line_start..last_line_end];
-    let column = offset - last_line_start + 1;
+    // find the next line ending (to construct the last line)
+    let mut last_line_ending = input.len() - 1;
+    for (i, char) in input[min(input.len() - 1, offset + 1)..].char_indices() {
+        // find the next line break ('\n' or '\r\n')
+        if char == '\n' || char == '\r' {
+            last_line_ending = i + offset;
+            break;
+        }
 
-    (lines, column, last_line)
+        if char == '\t' {
+            tab_in_line_found = true;
+        }
+    }
+
+    // get the last line slice
+    let last_line = &input[line_start_offset..last_line_ending + 1];
+
+    if !tab_in_line_found {
+        return (line, column, Cow::Borrowed(last_line));
+    }
+
+    // the last line needs special care because it contains tab bytes ('\t')
+    let last_line = last_line.replace('\t', "    ");
+    (line, column, Cow::Owned(last_line))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unix_line_and_column_info() {
+        let whole = "first line\nsecond line\nthird line\nfourth line";
+        let sub = &whole[29..];
+
+        let (lines, columns, last_line) = get_line_and_column_of_subslice(whole, sub);
+
+        assert_eq!(lines, 3);
+        assert_eq!(columns, 7);
+        assert_eq!(last_line, "third line");
+    }
+
+    #[test]
+    fn test_windows_line_and_column_info() {
+        let whole = "first line\r\nsecond line\r\nthird line\r\nfourth line";
+        let sub = &whole[31..];
+
+        let (lines, columns, last_line) = get_line_and_column_of_subslice(whole, sub);
+
+        assert_eq!(lines, 3);
+        assert_eq!(columns, 7);
+        assert_eq!(last_line, "third line");
+    }
+
+    #[test]
+    fn test_tabs_line_and_column_info() {
+        let whole = "first line\nsecond\tline\nthird line\nfourth line";
+        let sub = &whole[18..];
+
+        let (lines, columns, last_line) = get_line_and_column_of_subslice(whole, sub);
+
+        assert_eq!(lines, 2);
+        assert_eq!(columns, 11);
+        // output should have sanitized the '\t' into four spaces because columns should count each tab as 4 spaces by default.
+        assert_eq!(last_line, "second    line");
+    }
+
+    #[test]
+    fn test_edges_line_and_column_info() {
+        // slice starts at first character in the input
+        let whole = "first\tline\nsecond line\nthird line\nfourth line";
+        let sub = &whole[..];
+
+        let (lines, columns, last_line) = get_line_and_column_of_subslice(whole, sub);
+
+        assert_eq!(lines, 1);
+        assert_eq!(columns, 1);
+        assert_eq!(last_line, "first    line");
+
+        // slices starts at last character in the input
+        let whole = "first line\nsecond line\nthird line\nfourth line";
+        let sub = &whole[(whole.len() - 1)..];
+
+        let (lines, columns, last_line) = get_line_and_column_of_subslice(whole, sub);
+
+        assert_eq!(lines, 4);
+        assert_eq!(columns, 11);
+        assert_eq!(last_line, "fourth line");
+
+        // slice starts after last character in the input (slice is empty).
+        let whole = "first line\nsecond line\nthird line\nfourth line";
+        let sub = &whole[whole.len()..];
+
+        let (lines, columns, last_line) = get_line_and_column_of_subslice(whole, sub);
+
+        assert_eq!(lines, 4);
+        assert_eq!(columns, 12);
+        assert_eq!(last_line, "fourth line");
+    }
+
+    #[test]
+    fn test_utf8_chars_line_and_column_info() {
+        let whole = "first line\nsecond line\nthird🙂line\nfourth line";
+        let sub = &whole[32..];
+
+        let (lines, columns, last_line) = get_line_and_column_of_subslice(whole, sub);
+
+        assert_eq!(lines, 3);
+        assert_eq!(columns, 7);
+        assert_eq!(last_line, "third🙂line");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,15 +159,14 @@ mod tests {
 
     #[test]
     fn test_missing_quote_in_tag_argument() {
-        let input = "
-                <p class=swag-migration-index-modal-abort-migration-confirm-dialog-hint\">
+        let input = "<p class=swag-migration-index-modal-abort-migration-confirm-dialog-hint\">
                     Hello world
                 </p>";
         let result = parse(input).unwrap_err();
 
         let pretty = result.pretty_helpful_error_string(input);
         //println!("{}", pretty);
-        assert_eq!(pretty, "Parsing goes wrong in line 1 and column 26 :\n                <p class=swag-migration-index-modal-abort-migration-confirm-dialog-hint\">\n                         ^\n                         |\nmissing \'\"\' quote");
+        assert_eq!(pretty, "Parsing goes wrong in line 1 and column 10 :\n<p class=swag-migration-index-modal-abort-migration-confirm-dialog-hint\">\n         ^\n         |\nmissing \'\"\' quote");
     }
 
     #[test]

--- a/src/parser/twig.rs
+++ b/src/parser/twig.rs
@@ -262,12 +262,10 @@ pub(crate) fn twig_set_capture_block<R, T: GenericChildParser<R>>(
 pub(crate) fn twig_if_block<R, T: GenericChildParser<R>>(input: Input) -> IResult<TwigIf<R>> {
     let (remaining, expression) = twig_expression_opening_block(input)?;
     let (remaining, children) = T::generic_parse_children(remaining)?;
-    let mut arms = vec![];
-
-    arms.push(TwigIfArm {
+    let mut arms = vec![TwigIfArm {
         expression: Some(expression),
         children,
-    });
+    }];
 
     let mut outer_remaining = remaining;
     loop {


### PR DESCRIPTION
closes #2 

Also added support for UTF-8 encoded text inside the error reporting. So it should report the right line and column numbers and print the right line in all cases now.